### PR TITLE
bash のスクリプト実行中の上書き実験

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,4 @@ jobs:
           cache: 'pip'
       - run: pip install -r requirements.txt
       - name: playbook
-        run: ansible-playbook -i hosts site.yml 
+        run: ansible-playbook -i hosts site.yml

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,6 +11,8 @@ provisioner:
   ansible_config: ./test/test-ansible.cfg
   chef_bootstrap_url: nil
   use_instance_name: true
+  environment_vars:
+    CI: "true"
 
 platforms:
   - name: ubuntu/focal64

--- a/roles/bash-cp-test/defaults/main.yml
+++ b/roles/bash-cp-test/defaults/main.yml
@@ -1,0 +1,1 @@
+test_dir: "{{ ansible_env.HOME }}/test/"

--- a/roles/bash-cp-test/files/bar.sh
+++ b/roles/bash-cp-test/files/bar.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 30
+echo bar

--- a/roles/bash-cp-test/files/foo.sh
+++ b/roles/bash-cp-test/files/foo.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 30
+echo foo

--- a/roles/bash-cp-test/tasks/main.yml
+++ b/roles/bash-cp-test/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Test bash copy on running
+  import_tasks: test-main.yml
+  when: lookup('env', 'CI')

--- a/roles/bash-cp-test/tasks/test-loop.yml
+++ b/roles/bash-cp-test/tasks/test-loop.yml
@@ -1,0 +1,56 @@
+---
+
+- name: Copy foo.sh to test.sh
+  copy:
+    src: "foo.sh"
+    dest: "{{ test_dir }}/test.sh"
+    mode: 0755
+
+- name: ls
+  command: ls -i {{ test_dir }}
+  register: inode1
+
+- name: Run
+  shell: "{{ test_dir }}/test.sh > {{ log_file }}"
+  register: result_check
+  async: 60
+  poll: 0
+
+- name: Override bar (cp)
+  shell: "cp {{ test_dir }}/bar.sh {{ test_dir }}/test.sh"
+  when: not bar_override_copy_module
+
+- name: Override bar (copy module)
+  copy:
+    src: "bar.sh"
+    dest: "{{ test_dir }}/test.sh"
+    mode: 0755
+  when: bar_override_copy_module
+
+- name: ls
+  command: ls -i {{ test_dir }}
+  register: inode2
+
+- name: wait
+  async_status:
+    jid: "{{ result_check.ansible_job_id }}"
+  register: async_poll_results
+  until: async_poll_results.finished
+  retries: 30
+  delay: 1
+
+- name: Result file
+  shell: "cat {{ log_file }}"
+  register: result_file
+
+- name: Show inode (before)
+  debug:
+    var: inode1.stdout
+
+- name: Show inode (after)
+  debug:
+    var: inode2.stdout
+
+- name: Show result
+  debug:
+    msg: "{{ result_file.stdout }}"

--- a/roles/bash-cp-test/tasks/test-main.yml
+++ b/roles/bash-cp-test/tasks/test-main.yml
@@ -1,0 +1,43 @@
+---
+- name: Create test directory
+  file:
+    path: "{{ test_dir }}"
+    mode: 0755
+    state: directory
+    recurse: true
+
+- name: Copy file
+  copy:
+    src: "{{ item }}"
+    dest: "{{ test_dir }}/{{ item }}"
+    mode: 0755
+  with_items:
+    - foo.sh
+    - bar.sh
+
+- name: Test copy module
+  vars:
+    bar_override_copy_module: true
+    log_file: "{{ ansible_env.HOME }}/log-copy-module.txt"
+  import_tasks: test-loop.yml
+
+- name: Test shell cp
+  vars:
+    bar_override_copy_module: false
+    log_file: "{{ ansible_env.HOME }}/log-shell-copy.txt"
+  import_tasks: test-loop.yml
+
+- name: Result file
+  shell: "cat {{ ansible_env.HOME }}/{{ item }}"
+  register: result_file
+  with_items:
+    - log-copy-module.txt
+    - log-shell-copy.txt
+
+- name: Show result
+  debug:
+    msg: "{{ item.stdout }}"
+  with_items:
+    - "{{ result_file.results }}"
+  loop_control:
+      label: "{{ item.item }}"

--- a/site.yml
+++ b/site.yml
@@ -2,3 +2,4 @@
 - hosts: local_machine
   roles:
     - role: dotfiles
+    - role: bash-cp-test

--- a/test-playbook.yml
+++ b/test-playbook.yml
@@ -2,3 +2,4 @@
 - hosts: test-*
   roles:
     - role: dotfiles
+    - role: bash-cp-test


### PR DESCRIPTION
bash でスクリプト実行中に上書きすると書き換わった内容が読まれる挙動により意図しない処理がされることがある。
話題になっていたが、ansible の copy モジュールとかで .sh を配布してたりしているので、
同じことにならないか調べてみた。

refs:

* [スーパーコンピュータシステムのファイル消失のお詫び | お知らせ | 京都大学情報環境機構](https://www.iimc.kyoto-u.ac.jp/ja/whatsnew/information/detail/211228056999.html)
* [bash スクリプトの実行中上書き動作について](https://zenn.dev/mattn/articles/5af86b61004bdc) 

----

結果としては大丈夫でした。
